### PR TITLE
Generate crater run URLs in reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,17 @@ To run the program, for example on [pr-63247], first go to the @craterbot's
 [completion message], and then [open the full report][full-report]. Once there,
 go to the [downloads] section, click on [regressed crates] to get the
 `regressed.tar.gz` file. Now extract the file into the directory `regressed`.
-Inside `my_dir` there should be `reg` and `gh` for crates.io and GitHub respectively.
-Once done, compile and run `crater-cat-errors` using:
 
-```
-cargo build && RUST_LOG=info ./target/debug/crater-cat-errors ./regressed/reg report.md
+The script below, as of this writing, will do this (where `RUN_ID` is the crater
+run name). `PART_ID` can be found by going to any regression link; it is the
+`end=` parameter to crater (e.g., `beta-2020-02-05` for the 1.42 crater run).
+
+```bash
+RUN_ID=beta-1.42-1
+PART_ID=beta-2020-02-05
+wget https://crater-reports.s3.amazonaws.com/$RUN_ID/logs-archives/regressed.tar.gz
+tar xf regressed.tar.gz
+RUST_LOG=info cargo run -- $RUN_ID/$PART_ID=./regressed
 ```
 
 Your report will now be in `report.md`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap as Map;
-use std::path::{Path, PathBuf};
-use std::io::{self, Read as _, Write as _};
 use std::fs;
+use std::io::{self, Read as _};
+use std::path::{Path, PathBuf};
 
-use log::{info, debug};
+use log::{debug, info};
 
 fn main() -> io::Result<()> {
     env_logger::init();
@@ -11,12 +11,26 @@ fn main() -> io::Result<()> {
 
     let mut args = std::env::args();
     drop(args.next());
-    let analyze_dir = args.next().unwrap();
-    let analyze_dir = Path::new(&analyze_dir);
-    let save_report_to = args.next().unwrap();
-    let save_report_to = Path::new(&save_report_to);
+    let mut regressions = Map::new();
+    let mut report_path = Path::new("report.md");
+    for arg in args {
+        if !arg.contains('=') {
+            report_path = Path::new(arg);
+            break;
+        }
+        let mut parts = arg.splitn(2, '=');
+        let crater_run_name = parts.next().expect("first part before =").to_string();
+        let analyze_dir = Path::new(parts.next().expect("second part after ="));
 
-    let regressions = collect_regression_paths(analyze_dir)?;
+        regressions.extend(collect_regression_paths(
+            crater_run_name.clone(),
+            &analyze_dir.join("gh"),
+        )?);
+        regressions.extend(collect_regression_paths(
+            crater_run_name.clone(),
+            &analyze_dir.join("reg"),
+        )?);
+    }
     debug!("the regression map is: {:#?}", regressions);
 
     let errors = collect_errors(regressions)?;
@@ -25,54 +39,72 @@ fn main() -> io::Result<()> {
     let report = generate_report(errors);
     debug!("the report is:\n{}", report);
 
-    let mut out_file = fs::File::create(save_report_to)?;
-    write!(&mut out_file, "{}", report)?;
+    std::fs::write(&report_path, report)?;
 
     Ok(())
 }
 
 fn generate_report(errors: ErrorMap) -> String {
-    errors.iter()
+    errors
+        .iter()
         .map(|(error, krates)| {
             let mut lines = vec![
                 format!("### {}", error),
                 format!("Number of crates regressed: {}", krates.len()),
-                "<details>".to_string(),
+                "<details>\n".to_string(),
             ];
-            lines.extend(krates.iter().map(|(n, v)| format!("- `{}-{}`", n, v)));
-            lines.push("</details>".to_string());
-            lines.join("\n\n")
+            lines.extend(krates.iter().map(|(run, (n, v))| {
+                if v.chars().next().unwrap().is_digit(10) {
+                    // crates.io
+                    format!(
+                        "- [`{} v{}`](https://crater-reports.s3.amazonaws.com/{}/reg/{}-{}/log.txt)",
+                        n, v, run, n, v
+                    )
+                } else {
+                    // github
+                    format!(
+                        "- [`{}/{}`](https://crater-reports.s3.amazonaws.com/{}/gh/{}.{}/log.txt)",
+                        n, v, run, n, v
+                    )
+                }
+            }));
+            lines.push("\n</details>".to_string());
+            lines.join("\n")
         })
         .collect::<Vec<_>>()
         .join("\n\n")
 }
 
-type ErrorMap = Map<String, Vec<Crate>>;
+type ErrorMap = Map<String, Vec<(String, Crate)>>;
 
 fn collect_errors(regressions: RegressionMap) -> io::Result<ErrorMap> {
     let mut map: ErrorMap = Map::new();
-    for (krate, path) in regressions {
+    for (krate, (crater_run, path)) in regressions {
         info!("processing regression {}-{}: {:#?}", krate.0, krate.1, path);
         let contents = read_file_to_string(&path)?;
         let errors = process_regression_file(&contents);
         for error in errors {
             map.entry(error.to_string())
                 .or_default()
-                .push(krate.clone());
+                .push((crater_run.clone(), krate.clone()));
         }
     }
     Ok(map)
 }
 
-fn process_regression_file(contents: &str) -> Vec<&str> {
-    let mut contents = contents.lines()
+fn process_regression_file(contents: &str) -> Vec<String> {
+    let mut contents = contents
+        .lines()
         .filter(|l| l.starts_with("[INFO] [stderr]"))
         .map(|l| l.trim_start_matches("[INFO] [stderr]").trim())
         .filter(|l| l.starts_with("error:") || l.starts_with("error["))
         .filter(|l| !l.starts_with("error: aborting"))
-        .filter(|l| !l.starts_with("error: Could not compile"))
+        .filter(|l| !l.starts_with("error: could not compile"))
+        .filter(|l| !l.starts_with("error: Compilation failed, aborting rustdoc"))
+        .filter(|l| !l.starts_with("error: Could not document"))
         .filter(|l| !l.starts_with("error: build failed"))
-        .filter(|l| !l.starts_with("error: the lock file /mnt"))
+        .filter(|l| !l.starts_with("error: the lock file"))
+        .map(|l| erase_backtick_contents(l))
         .collect::<Vec<_>>();
 
     contents.sort();
@@ -80,6 +112,28 @@ fn process_regression_file(contents: &str) -> Vec<&str> {
 
     debug!("filtered regression contents: {:#?}", contents);
     contents
+}
+
+fn erase_backtick_contents(line: &str) -> String {
+    let mut newline = String::new();
+    let mut in_backticks = false;
+    for ch in line.chars() {
+        match ch {
+            '`' => {
+                if in_backticks {
+                    newline.push_str("...");
+                }
+                in_backticks = !in_backticks;
+                newline.push(ch);
+            }
+            _ => {
+                if !in_backticks {
+                    newline.push(ch);
+                }
+            }
+        }
+    }
+    newline
 }
 
 fn read_file_to_string(path: &Path) -> io::Result<String> {
@@ -90,9 +144,9 @@ fn read_file_to_string(path: &Path) -> io::Result<String> {
 
 type Crate = (String, String);
 
-type RegressionMap = Map<Crate, PathBuf>;
+type RegressionMap = Map<Crate, (String, PathBuf)>;
 
-fn collect_regression_paths(dir: &Path) -> io::Result<RegressionMap> {
+fn collect_regression_paths(name: String, dir: &Path) -> io::Result<RegressionMap> {
     let mut paths = Map::new();
 
     info!("collecting paths in: {}", dir.display());
@@ -115,8 +169,13 @@ fn collect_regression_paths(dir: &Path) -> io::Result<RegressionMap> {
                 let path = entry.path();
                 assert!(!path.is_dir());
                 let file_name = entry.file_name();
-                if file_name.to_str().unwrap().starts_with("try") {
-                    paths.insert((crate_name.clone(), crate_version.clone()), path);
+                if file_name.to_str().unwrap().starts_with("beta-")
+                    || file_name.to_str().unwrap().starts_with("try")
+                {
+                    paths.insert(
+                        (crate_name.clone(), crate_version.clone()),
+                        (name.clone(), path),
+                    );
                 }
             }
         }


### PR DESCRIPTION
This changes the run syntax to:

```
crater-cat-errors <dir...> [<report.md path>]
```

where dir is, for example, beta-1.42-1/beta-2020-02-05=regressed

The directory is the same as before, minus the /reg or /gh suffix, which is
added by the code now. Results across all provided directories are merged.

The report.md path is optional, and will default to report.md
